### PR TITLE
Prevent lengthy hostname from printing on top of version on homepage

### DIFF
--- a/fpms/modules/pages/homepage.py
+++ b/fpms/modules/pages/homepage.py
@@ -613,6 +613,13 @@ class HomePage(object):
 
         return height
 
+    @staticmethod
+    def trim_hostname(hostname) -> str:
+        out = ""
+        if len(hostname) > 15:
+            out = hostname[0:13] + ".."
+        return out 
+
     def system_bar(self, g_vars, x=0, y=0, padding=2, width=PAGE_WIDTH, height=SYSTEM_BAR_HEIGHT):
 
         canvas = g_vars['draw']
@@ -621,7 +628,8 @@ class HomePage(object):
         canvas.rectangle((x, y, width, y + height), fill=THEME.system_bar_background.value)
 
         # Draw hostname
-        hostname = g_vars['hostname']
+        hostname = self.trim_hostname(g_vars['hostname'])
+
         canvas.text((x + padding, y + padding), hostname, font=SMART_FONT, fill=THEME.system_bar_foreground.value)
 
         # Draw version

--- a/fpms/modules/pages/homepage.py
+++ b/fpms/modules/pages/homepage.py
@@ -614,11 +614,10 @@ class HomePage(object):
         return height
 
     @staticmethod
-    def trim_hostname(hostname) -> str:
-        out = ""
+    def trim_lengthy_hostname(hostname) -> str:
         if len(hostname) > 15:
-            out = hostname[0:13] + ".."
-        return out 
+            return hostname[0:13] + ".."
+        return hostname
 
     def system_bar(self, g_vars, x=0, y=0, padding=2, width=PAGE_WIDTH, height=SYSTEM_BAR_HEIGHT):
 
@@ -628,7 +627,7 @@ class HomePage(object):
         canvas.rectangle((x, y, width, y + height), fill=THEME.system_bar_background.value)
 
         # Draw hostname
-        hostname = self.trim_hostname(g_vars['hostname'])
+        hostname = self.trim_lengthy_hostname(g_vars['hostname'])
 
         canvas.text((x + padding, y + padding), hostname, font=SMART_FONT, fill=THEME.system_bar_foreground.value)
 


### PR DESCRIPTION
Current:

![image](https://user-images.githubusercontent.com/13954434/147605446-7fd259be-65c9-4159-bb4c-7f1923534538.png)

Changed:

![image](https://user-images.githubusercontent.com/13954434/147605458-0e5970b6-60e6-4cb5-8c32-5ecbfdeb4c1a.png)
