### PR TITLE
Dynamic timezone menu

### DIFF
--- a/fpms/fpms.py
+++ b/fpms/fpms.py
@@ -170,7 +170,9 @@ optional options:
         'eth_last_reachability_result' : False,# Last reachability state
         'scan_file' : '',                  # Location to save scans
         'profiler_beaconing' : False,          # Indicates if the profiler is running
-        'profiler_last_profile_date': None # The date of the last profile
+        'profiler_last_profile_date': None, # The date of the last profile
+        'timezones_available' : [],         # The list of Timezones the system can support
+        'timezone_selected' : None          # The timezone selected from the menu for use in other functions
     }
 
     ############################
@@ -210,6 +212,9 @@ optional options:
     profiler = Profiler(g_vars)
     g_vars['profiler_last_profile_date'] = profiler.profiler_last_profile_date()
     g_vars['profiler_beaconing'] = profiler.profiler_beaconing()
+
+    timezone = TimeZone(g_vars)
+    timezones_available = timezone.get_timezones_menu_format()
 
     ###########################
     # Network menu area utils
@@ -426,6 +431,11 @@ optional options:
         system_obj = System(g_vars)
         system_obj.show_date(g_vars)
 
+    def set_time_zone():
+        g_vars['timezone_selected'] = timezones_available[g_vars['current_menu_location'][3]]['timezones'][g_vars['current_menu_location'][4]]
+        system_obj = TimeZone(g_vars)
+        system_obj.set_time_zone_from_gvars(g_vars)
+
     def set_time_zone_london():
         system_obj = TimeZone(g_vars)
         system_obj.set_time_zone_london(g_vars)
@@ -543,6 +553,13 @@ optional options:
     # menu structure here
     #######################
 
+
+    # translate the timezone list into menu items (needs to be after definition of set_time_zone)
+    for timezones_country in timezones_available:
+        g_vars['timezones_available'].append({"name": timezones_country['country'], "action": []})
+        for timezone in timezones_country['timezones']:
+            g_vars['timezones_available'][-1]['action'].append({"name": timezone, "action": [{"name": "Confirm & Reboot", "action": set_time_zone}]})
+
     # assume classic mode menu initially...
     menu = [
         {"name": "Network", "action": [
@@ -636,12 +653,16 @@ optional options:
         {"name": "System", "action": [
             {"name": "About", "action": show_about},
             {"name": "Battery", "action": show_battery},
+            # {"name": "Date & Time", "action": [
+            #     {"name": "Show Time & Zone", "action": show_date},
+            #     {"name": "Set Zone UK", "action": [
+            #         {"name": "Confirm & Reboot", "action": set_time_zone_london},]},
+            #     {"name": "Set Zone CZ", "action": [
+            #         {"name": "Confirm & Reboot", "action": set_time_zone_prague},]},
+            #     ]},
             {"name": "Date & Time", "action": [
                 {"name": "Show Time & Zone", "action": show_date},
-                {"name": "Set Zone UK", "action": [
-                    {"name": "Confirm & Reboot", "action": set_time_zone_london},]},
-                {"name": "Set Zone CZ", "action": [
-                    {"name": "Confirm & Reboot", "action": set_time_zone_prague},]},
+                {"name": "Set Timezone", "action": g_vars['timezones_available']},
                 ]},
             {"name": "Summary", "action": show_summary},
             {"name": "RF Domain", "action": [

--- a/fpms/fpms.py
+++ b/fpms/fpms.py
@@ -432,7 +432,10 @@ optional options:
         system_obj.show_date(g_vars)
 
     def set_time_zone():
-        g_vars['timezone_selected'] = timezones_available[g_vars['current_menu_location'][3]]['timezones'][g_vars['current_menu_location'][4]]
+        g_vars['timezone_selected'] = (timezones_available[g_vars['current_menu_location'][3]]['country'] + 
+        "/" + 
+        timezones_available[g_vars['current_menu_location'][3]]['timezones'][g_vars['current_menu_location'][4]])
+
         system_obj = TimeZone(g_vars)
         system_obj.set_time_zone_from_gvars(g_vars)
 

--- a/fpms/modules/time_zone.py
+++ b/fpms/modules/time_zone.py
@@ -4,6 +4,7 @@ import subprocess
 import fpms.modules.wlanpi_oled as oled
 import sys
 
+
 from fpms.modules.pages.simpletable import SimpleTable
 from fpms.modules.pages.pagedtable import PagedTable
 from fpms.modules.pages.alert import Alert
@@ -20,12 +21,37 @@ class TimeZone(object):
 
         # create alert
         self.alert_obj = Alert(g_vars)
+    
+    def get_timezones_menu_format(self):
+        """
+        Returns a dictionary of supported Timezones as {country, [timezones]}, the timezones are filtered into country menus
+        The menu names are used as the parameter for the TIME_ZONE_FILE command so show on the screen in long form : country/city
+        """
+        timezone_menu_list = []
+        try:
+            timezones_available = subprocess.getoutput(f"{TIME_ZONE_FILE} list").splitlines()
+            time.sleep(1)
 
-    def set_time_zone_london(self, g_vars):
-        self.alert_obj.display_popup_alert(g_vars, 'Setting time zone', delay=2)
+            # create a set of countries defined as the first part of the text split with '/'
+            countries = sorted(set([c.split('/', 1)[0] for c in timezones_available])) 
+
+            # Iterate the countries and then create array of timezones for that country
+            for country in countries:
+                timezone_menu_list.append({"country": country, "timezones": []})
+                for timezone in filter(lambda c: c.startswith(country), timezones_available):
+                    timezone_menu_list[-1]['timezones'].append(timezone)
+
+            return timezone_menu_list
+
+        except subprocess.CalledProcessError as exc:
+            return None
+
+    def set_time_zone_from_gvars(self, g_vars):
+        timezone_selected = g_vars['timezone_selected']
+        self.alert_obj.display_popup_alert(g_vars, 'Setting TZ: {0}'.format(timezone_selected), delay=2)
 
         try:
-            alert_msg = subprocess.check_output(f"{TIME_ZONE_FILE} set Europe/London", shell=True).decode()
+            alert_msg = subprocess.check_output(f"{TIME_ZONE_FILE} set {timezone_selected}", shell=True).decode()
             time.sleep(1)
         except subprocess.CalledProcessError as exc:
             print(exc)
@@ -41,22 +67,42 @@ class TimeZone(object):
         os.system('reboot')
         return
 
-    def set_time_zone_prague(self, g_vars):
-        self.alert_obj.display_popup_alert(g_vars, 'Setting time zone', delay=2)
+    # def set_time_zone_london(self, g_vars):
+    #     self.alert_obj.display_popup_alert(g_vars, 'Setting time zone', delay=2)
 
-        try:
-            alert_msg = subprocess.check_output(f"{TIME_ZONE_FILE} set Europe/Prague", shell=True).decode()
-            time.sleep(1)
-        except subprocess.CalledProcessError as exc:
-            print(exc)
-            self.alert_obj.display_alert_error(g_vars, 'Failed to set time zone')
-            g_vars['display_state'] = 'menu'
-            return
+    #     try:
+    #         alert_msg = subprocess.check_output(f"{TIME_ZONE_FILE} set Europe/London", shell=True).decode()
+    #         time.sleep(1)
+    #     except subprocess.CalledProcessError as exc:
+    #         print(exc)
+    #         self.alert_obj.display_alert_error(g_vars, 'Failed to set time zone')
+    #         g_vars['display_state'] = 'menu'
+    #         return
 
-        self.alert_obj.display_popup_alert(g_vars, 'Successfully set', delay=1)
-        g_vars['display_state'] = 'menu'
-        g_vars['shutdown_in_progress'] = True
-        oled.drawImage(g_vars['reboot_image'])
-        time.sleep(1)
-        os.system('reboot')
-        return
+    #     self.alert_obj.display_popup_alert(g_vars, 'Successfully set', delay=1)
+    #     g_vars['display_state'] = 'menu'
+    #     g_vars['shutdown_in_progress'] = True
+    #     oled.drawImage(g_vars['reboot_image'])
+    #     time.sleep(1)
+    #     os.system('reboot')
+    #     return
+
+    # def set_time_zone_prague(self, g_vars):
+    #     self.alert_obj.display_popup_alert(g_vars, 'Setting time zone', delay=2)
+
+    #     try:
+    #         alert_msg = subprocess.check_output(f"{TIME_ZONE_FILE} set Europe/Prague", shell=True).decode()
+    #         time.sleep(1)
+    #     except subprocess.CalledProcessError as exc:
+    #         print(exc)
+    #         self.alert_obj.display_alert_error(g_vars, 'Failed to set time zone')
+    #         g_vars['display_state'] = 'menu'
+    #         return
+
+    #     self.alert_obj.display_popup_alert(g_vars, 'Successfully set', delay=1)
+    #     g_vars['display_state'] = 'menu'
+    #     g_vars['shutdown_in_progress'] = True
+    #     oled.drawImage(g_vars['reboot_image'])
+    #     time.sleep(1)
+    #     os.system('reboot')
+    #     return

--- a/fpms/modules/time_zone.py
+++ b/fpms/modules/time_zone.py
@@ -39,7 +39,7 @@ class TimeZone(object):
             for country in countries:
                 timezone_menu_list.append({"country": country, "timezones": []})
                 for timezone in filter(lambda c: c.startswith(country), timezones_available):
-                    timezone_menu_list[-1]['timezones'].append(timezone)
+                    timezone_menu_list[-1]['timezones'].append(timezone.split('/', 1)[-1])
 
             return timezone_menu_list
 


### PR DESCRIPTION
Reads the timezone list and uses it to create the menus to set one of the timezones
Arranged into country menus to allow for easier searching

Known issue: Timezone display is the actual timezone value and some of these are too long to fit on the screen. An enhancement could be to remove the country from the final printed value and then rejoin it to the country when calling the function.