### PR TITLE
Add Ruckus Cloud Tests to FPMS

### DIFF
--- a/fpms/AUTHORS.md
+++ b/fpms/AUTHORS.md
@@ -6,9 +6,10 @@ Alphabetical order:
 * Ben Toner, @ben__toner, <https://github.com/bentumbler>
 * Colin Vallance, @_crv, <https://github.com/crvallance>
 * Daniel Finimundi, @danielmundi, <https://github.com/danielmundi>
+* iamk3, iamk3, <https://github.com/iamk3>
 * Jerry Olla, @jolla, <https://github.com/jolla>
 * Jiri Brejcha, @jiribrejcha, <https://github.com/jiribrejcha>
-* Josh Schmelzle, @joshschmelzle, <https://github.com/joshschmelzle>
-* Nigel Bowden, @wifinigel, <https://github.com/wifinigel>
 * Joel Crane, @potato_fi
+* Josh Schmelzle, @joshschmelzle, <https://github.com/joshschmelzle>
 * Nick Turner, @nickjvturner, <https://github.com/nickjvturner>
+* Nigel Bowden, @wifinigel, <https://github.com/wifinigel>

--- a/fpms/fpms.py
+++ b/fpms/fpms.py
@@ -283,7 +283,7 @@ optional options:
 
     def show_ruckus_test():
         utils_obj = CloudUtils(g_vars)
-        utils_obj.test_ruckus_cloud
+        utils_obj.test_ruckus_cloud(g_vars)
 
     def show_mist_test():
         utils_obj = CloudUtils(g_vars)

--- a/fpms/fpms.py
+++ b/fpms/fpms.py
@@ -281,6 +281,10 @@ optional options:
         utils_obj = Utils(g_vars)
         utils_obj.show_speedtest(g_vars)
 
+    def show_ruckus_test():
+        utils_obj = CloudUtils(g_vars)
+        utils_obj.test_ruckus_cloud
+
     def show_mist_test():
         utils_obj = CloudUtils(g_vars)
         utils_obj.test_mist_cloud(g_vars)
@@ -592,6 +596,7 @@ optional options:
             {"name": "Cloud Tests", "action": [
                 {"name": "Run Aruba Test", "action": show_aruba_test},
                 {"name": "Run Mist Test", "action": show_mist_test},
+                {"name": "Run Ruckus Test", "action": show_ruckus_test},
             ]
             },
             {"name": "Port Blinker", "action": [

--- a/fpms/modules/cloud_tests.py
+++ b/fpms/modules/cloud_tests.py
@@ -239,3 +239,84 @@ class CloudUtils(object):
 
         # re-enable front panel keys
         g_vars["disable_keys"] = False
+
+    def test_ruckus_cloud(self, g_vars):
+        """
+        Perform a series of connectivity tests to see if Ruckus Cloud is available:
+
+        1. Is eth0 port up?
+        2. Do we get an IP address via DHCP?
+        3. Can we resolve address ruckus.cloud?
+        4. Can get get an http 302 response to https://ruckus.cloud
+
+        """
+
+        # ignore any more key presses as this could cause us issues
+        g_vars["disable_keys"] = True
+
+        # Has test been run already?
+        if g_vars["result_cache"] == False:
+
+            # record test success/fail
+            test_fail = False
+
+            # create empty table
+            item_list = ["", "", "", ""]
+
+            self.alert_obj.display_popup_alert(g_vars, "Running...")
+
+            # Is eth0 up?
+            cmd = "/sbin/ethtool eth0 | grep 'Link detected'| awk '{print $3}'"
+            result = subprocess.check_output(cmd, shell=True).decode().strip()
+
+            if result == "yes":
+                item_list[0] = "Eth0 Port Up: YES"
+            elif result == "no":
+                item_list[0] = "Eth0 Port Up: NO"
+                test_fail = True
+            else:
+                item_list[0] = "Eth0 Port Up: Unknown"
+                test_fail = True
+
+            # we're done if test failed
+            if not test_fail:
+                # Have we got an IP address?
+                cmd = "ip address show eth0 | grep 'inet ' | awk '{print $2}' | awk -F'/' '{print $1}'"
+                result = subprocess.check_output(cmd, shell=True).decode().strip()
+
+                if result:
+                    item_list[1] = "MyIP: {}".format(result)
+                else:
+                    item_list[1] = "MyIP: None"
+                    test_fail = True
+
+            if not test_fail:
+                # Can we resolve address ruckus.cloud?
+                try:
+                    socket.gethostbyname("ruckus.cloud")
+                    item_list[2] = "DNS: OK"
+                except:
+                    test_fail = True
+                    item_list[2] = "DNS: FAIL"
+
+            if not test_fail:
+                # Can we get an http 200 from https://ruckus.cloud ?
+                cmd = 'curl -k -s -L -o /dev/null -w "%{http_code}" https://ruckus.cloud'
+                result = subprocess.check_output(cmd, shell=True).decode()
+
+                if result == "200":
+                    item_list[3] = "HTTP: OK"
+                else:
+                    item_list[3] = "HTTP: FAIL"
+                    test_fail = True
+
+            # show results
+            self.simple_table_obj.display_simple_table(
+                g_vars, item_list, title="Ruckus Cloud"
+            )
+
+            # set flag to prevent constant refresh of screen
+            g_vars["result_cache"] = True
+
+        # re-enable front panel keys
+        g_vars["disable_keys"] = False


### PR DESCRIPTION
This adds basic Ruckus Cloud test to FPMS. I based this off of the existing Mist Cloud tests. The difference you will find is the URL of course, but Ruckus redirects https://ruckus.cloud to their SSO auth.ruckuswireless.com, so the curl command adds the "-L" option to follow the redirect.