### PR TITLE
Removing wconsole mode from wlanpi-fpms

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-fpms (1.4.12) unstable; urgency=medium
+
+  * Removing wireless console server mode
+
+  -- Jake Snyder <jsnyder81@gmail.com>  Sun, 15 Feb 2026 00:00:00 -0500
+
 wlanpi-fpms (1.4.11) unstable; urgency=medium
 
   * Added Arista CV-CUE cloud test
@@ -609,7 +615,7 @@ wlanpi-fpms (1.2.8-1) unstable; urgency=medium
 
 wlanpi-fpms (1.2.8) unstable; urgency=medium
 
-  * Adds WiFi QR code to hotspot, console, and server modes (press center
+  * Adds WiFi QR code to hotspot and server modes (press center
     button on home screen to display QR code)
   * Renames Utils > WPA Passphrase to Utils > SSID/Passphrase and changes it
     to show SSID, passphrase and WiFi QR code

--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,6 @@ Depends: libopenjp2-7,
          wlanpi-bluetooth,
          wlanpi-hotspot,
          wlanpi-server,
-         wlanpi-wconsole,
          wlanpi-profiler,
          ${misc:Depends},
          ${shlibs:Depends}

--- a/fpms/fpms.py
+++ b/fpms/fpms.py
@@ -85,7 +85,7 @@ g_vars = {
     'option_selected': 0,              # Content of currently selected menu level
     'current_menu_location': [0],      # Pointer to current location in menu structure
     'current_scroll_selection': 0,     # where we currently are in scrolling table
-    'current_mode': 'classic',         # Currently selected mode (e.g. wconsole/classic)
+    'current_mode': 'classic',         # Currently selected mode (e.g. classic/server)
     'start_up': True,                  # True if in initial (home page) start-up state
     'disable_keys': False,             # Set to true when need to ignore key presses
     'table_list_length': 0,            # Total length of currently displayed table
@@ -425,10 +425,6 @@ optional options:
     ############################
     # Modes area
     ############################
-    def wconsole_switcher():
-        mode_obj = Mode(g_vars)
-        mode_obj.wconsole_switcher(g_vars)
-
     def hotspot_switcher():
         mode_obj = Mode(g_vars)
         mode_obj.hotspot_switcher(g_vars)
@@ -769,10 +765,6 @@ optional options:
         ]
         },
         {"name": "Modes", "action": [
-            {"name": "Wi-Fi Console",   "action": [
-                {"name": "Confirm", "action": wconsole_switcher},
-            ]
-            },
             {"name": "Hotspot",   "action": [
                 {"name": "Confirm", "action": hotspot_switcher},
             ]
@@ -880,10 +872,6 @@ optional options:
     ]
 
     # update menu options data structure if we're in non-classic mode
-    if g_vars['current_mode'] == "wconsole":
-        switcher_dispatcher = wconsole_switcher
-        g_vars['home_page_name'] = "Wi-Fi Console"
-
     if g_vars['current_mode'] == "hotspot":
         switcher_dispatcher = hotspot_switcher
         g_vars['home_page_name'] = "Hotspot"

--- a/fpms/modules/constants.py
+++ b/fpms/modules/constants.py
@@ -78,7 +78,6 @@ ETHTOOL_FILE = '/sbin/ethtool'
 # Mode changer scripts
 MODE_FILE = '/etc/wlanpi-state'
 
-WCONSOLE_SWITCHER_FILE ='/opt/wlanpi-wconsole/wconsole_switcher'
 HOTSPOT_SWITCHER_FILE = '/opt/wlanpi-hotspot/hotspot_switcher'
 WIPERF_SWITCHER_FILE = '/opt/wlanpi-wiperf/wiperf_switcher'
 SERVER_SWITCHER_FILE = '/opt/wlanpi-server/server_switcher'

--- a/fpms/modules/env_utils.py
+++ b/fpms/modules/env_utils.py
@@ -65,7 +65,7 @@ class EnvUtils(object):
 
     def get_mode(self, MODE_FILE):
 
-        valid_modes = ['classic', 'wconsole', 'hotspot', 'wiperf', 'server', 'bridge']
+        valid_modes = ['classic', 'hotspot', 'wiperf', 'server', 'bridge']
 
         # check mode file exists and read mode...create with classic mode if not
         if os.path.isfile(MODE_FILE):

--- a/fpms/modules/modes.py
+++ b/fpms/modules/modes.py
@@ -6,7 +6,6 @@ import fpms.modules.wlanpi_oled as oled
 from fpms.modules.pages.alert import Alert
 from fpms.modules.pages.simpletable import SimpleTable
 from fpms.modules.constants import (
-    WCONSOLE_SWITCHER_FILE,
     HOTSPOT_SWITCHER_FILE,
     WIPERF_SWITCHER_FILE,
     SERVER_SWITCHER_FILE,
@@ -71,18 +70,6 @@ class Mode(object):
         g_vars['display_state'] = 'menu'
 
         return False
-
-    def wconsole_switcher(self, g_vars):
-
-        wconsole_switcher_file = WCONSOLE_SWITCHER_FILE
-
-        resource_title = "Wi-Fi Console"
-        mode_name = "wconsole"
-        resource_switcher_file = wconsole_switcher_file
-
-        # switch
-        self.switcher(g_vars, resource_title, resource_switcher_file, mode_name)
-        return True
 
 
     def hotspot_switcher(self, g_vars):

--- a/fpms/modules/pages/homepage.py
+++ b/fpms/modules/pages/homepage.py
@@ -256,11 +256,7 @@ class HomePage(object):
         mode_name = PLATFORM
         mode = self.classic_mode
 
-        if g_vars['current_mode'] == "wconsole":
-            if_name = "wlan0"
-            mode_name = "Wi-Fi Console"
-            mode = self.wconsole_mode
-        elif g_vars['current_mode'] == "hotspot":
+        if g_vars['current_mode'] == "hotspot":
             if_name = "wlan0"
             mode_name = "Hotspot"
             mode = self.hotspot_mode
@@ -351,12 +347,7 @@ class HomePage(object):
         g_vars['drawing_in_progress'] = True
         g_vars['display_state'] = 'page'
 
-        if g_vars['current_mode'] == "wconsole":
-            # get wlan0 IP
-            if_name = "wlan0"
-            mode_name = "Wi-Fi Console"
-
-        elif g_vars['current_mode'] == "hotspot":
+        if g_vars['current_mode'] == "hotspot":
             # get wlan0 IP
             if_name = "wlan0"
             mode_name = "Hotspot " + str(self.wifi_client_count()) + " clients"
@@ -515,19 +506,6 @@ class HomePage(object):
                 clients = str(client_count) + (" client" if client_count == 1 else " clients")
                 canvas.text((x + (PAGE_WIDTH - SMART_FONT.getbbox(clients)[2])/2, y), clients, font=SMART_FONT, fill=THEME.text_secondary_color.value)
                 y += 18
-
-            # Show the eth0 address
-            y += self.iface_summary(g_vars, "eth0", "LAN", x=x, y=y)
-
-            # Show the USB (OTG) address
-            y += self.iface_summary(g_vars, "usb0", "OTG", x=x, y=y)
-
-
-    def wconsole_mode(self, g_vars, x=0, y=0, padding=2):
-        if g_vars['home_page_alternate']:
-            self.wifi_qrcode(g_vars, x, y)
-        else:
-            y += self.iface_details(g_vars, "wlan0", x=x, y=y, padding=padding)
 
             # Show the eth0 address
             y += self.iface_summary(g_vars, "eth0", "LAN", x=x, y=y)


### PR DESCRIPTION
## Summary

Removes dedicated wconsole mode from wlanpi-fpms menus.


## Type of change

- [X] New feature


## Proposed change

Simplifies ongoing maintenance and testing of future releases.

## Testing

<!-- How was this tested? -->
- [X] Tested manually on a WLAN Pi

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used:  Gemini was used to validate that the fpms.py was valid and looked for any issues with the change.  All other suggestions were not actioned.

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [ ] This PR fixes/closes issue #_ (or relates to issue #_)
#145 

