### PR TITLE
Add DeviceID to wlan interface screen

### DIFF
--- a/fpms/modules/network.py
+++ b/fpms/modules/network.py
@@ -164,6 +164,26 @@ class Network(object):
             except Exception:
                 pass
 
+            # Device ID (USB or PCI)
+            try:
+                modalias_path = f"/sys/class/net/{interface}/device/modalias"
+                modalias = subprocess.check_output(
+                    f"cat {modalias_path}", shell=True).decode().strip()
+                bus = modalias.split(":")[0]
+                if bus == "usb":
+                    device_id = modalias.split(":")[1][1:10].replace("p", ":")
+                    page.append(f"DevID: {device_id}")
+                elif bus == "pci":
+                    vendor = subprocess.check_output(
+                        f"cat /sys/class/net/{interface}/device/vendor",
+                        shell=True).decode().strip()
+                    device = subprocess.check_output(
+                        f"cat /sys/class/net/{interface}/device/device",
+                        shell=True).decode().strip()
+                    page.append(f"DevID: {vendor}:{device}")
+            except Exception:
+                pass
+
             # Addr, SSID, Mode, Channel
             try:
                 iw_output = subprocess.check_output(f"{IW_FILE} {interface} info", shell=True).decode().strip()


### PR DESCRIPTION
## Summary

Implements device id on wlan interface page.   closes #109 

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Other: 

## Proposed change

Adds DevID to the wlan interfaces screen on FPMS.

## Testing

<!-- How was this tested? -->
- [ ] Added/updated automated tests
- [X] Tested manually on a WLAN Pi
- [ ] Tested in another environment

## AI assistance

- [X] I used AI/LLM assistance
- If yes: Tool(s) used: Claude Code

## Checklist

- [X] I have read the [contribution guidelines](https://github.com/WLAN-Pi/.github/blob/main/docs/contributing.md)
- [X] I targeted the correct branch (in general: `dev` for features/fixes, `main` for hotfixes)
- [X] This PR fixes/closes issue #_ (or relates to issue #_)

## Breaking changes

- **What breaks:** 
- **Migration needed:** 
