### PR TITLE
Fix ERE grep warning in preinst

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -2,7 +2,7 @@
 
 # Enable SPI interface for OLED display
 echo "Enabling SPI interface"
-if grep -q -E "^?dtparam=spi=" /boot/config.txt; then
+if grep -q -E "^#?dtparam=spi=" /boot/config.txt; then
 	sed -i 's/^#\?dtparam=spi=.*/dtparam=spi=on/' /boot/config.txt
 else
 	echo "dtparam=spi=on" >> /boot/config.txt


### PR DESCRIPTION
This PR fixes a grep ERE pattern syntax warning in the preinst script. Closes #140.