### PR TITLE
Handle float/zero RSSI values in scanner

### DIFF
--- a/fpms/modules/apps/scanner.py
+++ b/fpms/modules/apps/scanner.py
@@ -68,10 +68,25 @@ class Scanner(object):
             scan_output = subprocess.check_output(cmd, shell=True).decode().strip()
             networks = self.parse(scan_output)
 
-            # Sort results by RSSI
-            networks.sort(key = lambda x: x[2])
+            # Safely get RSSI helper
+            def get_rssi(x):
+                try:
+                    return float(x[2])
+                except (ValueError, IndexError):
+                    return 0.0
+
+            # Sort results by RSSI numerically (descending)
+            networks.sort(key=get_rssi, reverse=True)
 
             results = []
+            all_zero_rssi = len(networks) > 0 and all(get_rssi(x) == 0.0 for x in networks)
+
+            if all_zero_rssi and write_file != True:
+                results.append("Warning: Adapter")
+                results.append("does not support")
+                results.append("RSSI measurement")
+                results.append("---")
+
             for network in networks:
                 # BSSID
                 bssid = network[0].upper()
@@ -81,7 +96,7 @@ class Scanner(object):
                 channel = self.freq_to_channel(freq)
 
                 # RSSI
-                rssi = int(network[2])
+                rssi = int(round(get_rssi(network)))
 
                 # LAST SEEN
                 lastseen = network[3]

--- a/fpms/modules/templates/iw_scan.textfsm
+++ b/fpms/modules/templates/iw_scan.textfsm
@@ -1,6 +1,6 @@
 Value Required BSS (([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2}))
 Value Required FREQ (\d+)
-Value Required RSSI (-\d+)
+Value Required RSSI (-?\d+(?:\.\d+)?)
 Value Required LASTSEEN (\d+)
 Value SSID ([^\r\n]*)
 


### PR DESCRIPTION
This PR fixes a bug where the scanner app fails to show any results (hangs on Scanning...) when using a Wi-Fi adapter that reports a signal strength of 0.00 dBm. It updates the TextFSM parser to match optional signs and decimals, safely converts RSSI strings to numeric values, performs proper numeric sorting, and shows a warning on the screen if all scan results are 0 dBm (indicating RSSI is unsupported by the adapter). Closes #79.